### PR TITLE
Minor typo in `README.md` (example playbook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Install powerlevel10k for ohmyzsh:
 
     - hosts: servers
       roles:
-         - { role: diodonfrost.omyzsh, ohmyzsh_theme: powerlevel10k/powerlevel10k }
+         - { role: diodonfrost.ohmyzsh, ohmyzsh_theme: powerlevel10k/powerlevel10k }
          - { role: diodonfrost.p10k, zsh_plugin: ohmyzsh }
 
 Local Testing


### PR DESCRIPTION
In the `README.md`, the example playbook references the role `diodonfrost.omyzsh`, which should be `diodonfrost.ohmyzsh` instead.